### PR TITLE
Removing layer module

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Resources:
         KmsKeyModule: !GetAtt 'Key.Outputs.StackName' # optional
         VpcModule: !GetAtt 'Vpc.Outputs.StackName' # optional
         DeadLetterQueueModule: !GetAtt 'Queue.Outputs.StackName' # optional
-        LayerModule: !GetAtt 'Layer.Outputs.StackName' # optional
         Description: '' # optional
         Handler: 'example.handler' # required (file must be in the `lambda-src` folder)
         MemorySize: '128' # optional
@@ -48,6 +47,7 @@ Resources:
         EnvironmentVariable2: '' # optional
         EnvironmentVariable3: '' # optional
         ManagedPolicyArns: '' # optional
+        LayerArns: '' # optional
       TemplateURL: './node_modules/@cfn-modules/lambda-function/module.yml'
 ```
 
@@ -96,13 +96,6 @@ Resources:
     <tr>
       <td>DeadLetterQueueModule</td>
       <td>Stack name of <a href="https://www.npmjs.com/package/@cfn-modules/sqs-queue">sqs-queue module</a> where Lambda sends events to after the maximum number of retries was reached</td>
-      <td></td>
-      <td>no</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>LayerModule</td>
-      <td>Stack name of <a href="https://www.npmjs.com/package/@cfn-modules/lambda-layer">lambda-layer module</a></td>
       <td></td>
       <td>no</td>
       <td></td>
@@ -212,5 +205,19 @@ Resources:
       <td>no</td>
       <td></td>
     </tr>
+    <tr>
+      <td>LayerArns</td>
+      <td>Comma-delimited list of Layer ARNs to attach to the function</td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
   </tbody>
 </table>
+
+
+## Migration Guides
+
+### Migrate to 2.x.x
+
+* The `lambda-layer` module is no longer supported. Replace the `LayerModule` parameter with a comma-delimited list of Layer ARNs to attach to the function `LayerArns`. Define the Lambda layer in your own template.

--- a/README.md
+++ b/README.md
@@ -218,6 +218,6 @@ Resources:
 
 ## Migration Guides
 
-### Migrate to 2.x.x
+### Migrate to v2
 
 * The `lambda-layer` module is no longer supported. Replace the `LayerModule` parameter with a comma-delimited list of Layer ARNs to attach to the function `LayerArns`. Define the Lambda layer in your own template.

--- a/module.yml
+++ b/module.yml
@@ -251,7 +251,7 @@ Outputs:
   ModuleId:
     Value: 'lambda-function'
   ModuleVersion:
-    Value: '1.3.1'
+    Value: '2.0.0'
   StackName:
     Value: !Ref 'AWS::StackName'
   Arn:

--- a/module.yml
+++ b/module.yml
@@ -49,10 +49,6 @@ Parameters:
     Description: 'Optional but recommended for async invocations stack name of sqs-queue module where Lambda sends events to after the maximum number of retries was reached'
     Type: String
     Default: ''
-  LayerModule:
-    Description: 'Optional stack name of lambda-layer module.'
-    Type: String
-    Default: ''
   Description:
     Description: 'Optional description of the function'
     Type: String
@@ -116,17 +112,21 @@ Parameters:
     Description: 'Optional comma-delimited list of IAM managed policy ARNs to attach to the task''s IAM role'
     Type: String
     Default: ''
+  LayerArns:
+    Description: 'Optional comma-delimited list of Layer ARNs to attach to the function'
+    Type: String
+    Default: ''
 Conditions:
   HasAlertingModule: !Not [!Equals [!Ref AlertingModule, '']]
   HasKmsKeyModule: !Not [!Equals [!Ref KmsKeyModule, '']]
   HasDeadLetterQueueModule: !Not [!Equals [!Ref DeadLetterQueueModule, '']]
-  HasLayerModule: !Not [!Equals [!Ref LayerModule, '']]
   HasReservedConcurrentExecutions: !Not [!Equals [!Ref ReservedConcurrentExecutions, -1]]
   HasVpcModule: !Not [!Equals [!Ref VpcModule, '']]
   HasDependencyModule1: !Not [!Equals [!Ref DependencyModule1, '']]
   HasDependencyModule2: !Not [!Equals [!Ref DependencyModule2, '']]
   HasDependencyModule3: !Not [!Equals [!Ref DependencyModule3, '']]
   HasManagedPolicyArns: !Not [!Equals [!Ref ManagedPolicyArns, '']]
+  HasLayerArns: !Not [!Equals [!Ref LayerArns, '']]
 Resources:
   Role:
     Type: 'AWS::IAM::Role'
@@ -208,8 +208,7 @@ Resources:
       - SecurityGroupIds: [!Ref SecurityGroup]
         SubnetIds: !Split [',', {'Fn::ImportValue': !Sub '${VpcModule}-SubnetIdsPrivate'}]
       - !Ref 'AWS::NoValue'
-      Layers:
-      - !If [HasLayerModule, {'Fn::ImportValue': !Sub '${LayerModule}-Arn'}, !Ref 'AWS::NoValue']
+      Layers: !If [HasLayerArns, !Split [',', !Ref LayerArns], !Ref 'AWS::NoValue']
   ErrorsTooHighAlarm:
     Condition: HasAlertingModule
     Type: 'AWS::CloudWatch::Alarm'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfn-modules/lambda-function",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "description": "AWS Lambda function with automated IAM policy generation, encryption, log group and alerting",
   "author": "Michael Wittig <michael@widdix.de>",
   "license": "Apache-2.0",

--- a/test/layer.yml
+++ b/test/layer.yml
@@ -8,17 +8,16 @@ Parameters:
     Type: String
 Resources:
   Layer:
-    Type: 'AWS::CloudFormation::Stack'
+    Type: 'AWS::Lambda::LayerVersion'
     Properties:
-      Parameters:
-        ContentBucket: !Ref ContentBucket
-        ContentKey: !Ref ContentKey
-      TemplateURL: './node_modules/@cfn-modules/lambda-layer/module.yml'
+      Content:
+        S3Bucket: !Ref ContentBucket
+        S3Key: !Ref ContentKey
   Function:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
       Parameters:
         Handler: 'defaults.handler'
         Runtime: 'nodejs8.10'
-        LayerModule: !GetAtt 'Layer.Outputs.StackName'
+        LayerArns: !Ref Layer
       TemplateURL: './node_modules/@cfn-modules/lambda-function/module.yml'

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -91,11 +91,6 @@
     "@cfn-modules/lambda-function": {
       "version": "file:.."
     },
-    "@cfn-modules/lambda-layer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@cfn-modules/lambda-layer/-/lambda-layer-1.0.0.tgz",
-      "integrity": "sha512-6mo6Nzz5zC4oae6N/68Av5Q38mparTc80sZCrbzChENtxdxwdI8EDSs6iT49j5I6zP7PupMzgONk6Hgan3dv6A=="
-    },
     "@cfn-modules/s3-bucket": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@cfn-modules/s3-bucket/-/s3-bucket-1.2.0.tgz",
@@ -887,7 +882,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -955,7 +950,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -3714,7 +3709,7 @@
     },
     "sax": {
       "version": "1.2.1",
-      "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "semver": {
@@ -3864,7 +3859,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3897,7 +3892,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -5,7 +5,6 @@
     "ava": "0.25.0",
     "@cfn-modules/test": "0.4.0",
     "@cfn-modules/s3-bucket": "1.2.0",
-    "@cfn-modules/lambda-layer": "1.0.0",
     "@cfn-modules/lambda-function": "file:../"
   },
   "scripts": {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Removing the lamda-layer module as static exports do not work for layers.
