### PR TITLE
Add the ability to add client security groups

### DIFF
--- a/module.yml
+++ b/module.yml
@@ -116,6 +116,18 @@ Parameters:
     Description: 'Optional comma-delimited list of Layer ARNs to attach to the function'
     Type: String
     Default: ''
+  ClientSgModule1:
+    Description: 'Optional stack name of client-sg module to mark traffic from the Lambda.'
+    Type: String
+    Default: ''
+  ClientSgModule2:
+    Description: 'Optional stack name of client-sg module to mark traffic from the Lambda.'
+    Type: String
+    Default: ''
+  ClientSgModule3:
+    Description: 'Optional stack name of client-sg module to mark traffic from the Lambda.'
+    Type: String
+    Default: ''
 Conditions:
   HasAlertingModule: !Not [!Equals [!Ref AlertingModule, '']]
   HasKmsKeyModule: !Not [!Equals [!Ref KmsKeyModule, '']]
@@ -127,6 +139,9 @@ Conditions:
   HasDependencyModule3: !Not [!Equals [!Ref DependencyModule3, '']]
   HasManagedPolicyArns: !Not [!Equals [!Ref ManagedPolicyArns, '']]
   HasLayerArns: !Not [!Equals [!Ref LayerArns, '']]
+  HasClientSgModule1: !Not [!Equals [!Ref ClientSgModule1, '']]
+  HasClientSgModule2: !Not [!Equals [!Ref ClientSgModule2, '']]
+  HasClientSgModule3: !Not [!Equals [!Ref ClientSgModule3, '']]
 Resources:
   Role:
     Type: 'AWS::IAM::Role'
@@ -205,7 +220,11 @@ Resources:
         Mode: !Ref TracingConfigMode
       VpcConfig: !If
       - HasVpcModule
-      - SecurityGroupIds: [!Ref SecurityGroup]
+      - SecurityGroupIds:
+        - !Ref SecurityGroup
+        - !If [HasClientSgModule1, {'Fn::ImportValue': !Sub '${ClientSgModule1}-SecurityGroupId'}, !Ref 'AWS::NoValue']
+        - !If [HasClientSgModule2, {'Fn::ImportValue': !Sub '${ClientSgModule2}-SecurityGroupId'}, !Ref 'AWS::NoValue']
+        - !If [HasClientSgModule3, {'Fn::ImportValue': !Sub '${ClientSgModule3}-SecurityGroupId'}, !Ref 'AWS::NoValue']
         SubnetIds: !Split [',', {'Fn::ImportValue': !Sub '${VpcModule}-SubnetIdsPrivate'}]
       - !Ref 'AWS::NoValue'
       Layers: !If [HasLayerArns, !Split [',', !Ref LayerArns], !Ref 'AWS::NoValue']


### PR DESCRIPTION
Hi! As per #9...

I am shooting for a similar API to the [EC2 Module](https://github.com/cfn-modules/ec2-instance-amazon-linux) for adding references to the `client-sg` module. Let me know if I'm missing something here or it doesn't reflect the direction you are looking to go. The use case I am thinking of here is allowing access from the Lambda to anything inside the VPC, for example an RDS database. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
