### PR TITLE
Ignore INSUFFICIENT_DATA on alarms

### DIFF
--- a/module.yml
+++ b/module.yml
@@ -249,6 +249,7 @@ Resources:
       EvaluationPeriods: 1
       ComparisonOperator: GreaterThanThreshold
       Threshold: 0
+      TreatMissingData: 'ignore'
       AlarmActions:
       - 'Fn::ImportValue': !Sub '${AlertingModule}-Arn'
       OKActions:
@@ -268,6 +269,7 @@ Resources:
       EvaluationPeriods: 1
       ComparisonOperator: GreaterThanThreshold
       Threshold: 0
+      TreatMissingData: 'ignore'
       AlarmActions:
       - 'Fn::ImportValue': !Sub '${AlertingModule}-Arn'
       OKActions:


### PR DESCRIPTION
Closes #13 

My hope is that this would mean that lambda executions that occur after INSUFFICIENT_DATA periods would not trigger the alarm unless they change from their previous status.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
