### PR TITLE
Allow the function to have a custom name

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Resources:
         KmsKeyModule: !GetAtt 'Key.Outputs.StackName' # optional
         VpcModule: !GetAtt 'Vpc.Outputs.StackName' # optional
         DeadLetterQueueModule: !GetAtt 'Queue.Outputs.StackName' # optional
+        FunctionName: '' #optional
         Description: '' # optional
         Handler: 'example.handler' # required (file must be in the `lambda-src` folder)
         MemorySize: '128' # optional
@@ -109,6 +110,13 @@ Resources:
     <tr>
       <td>DeadLetterQueueModule</td>
       <td>Stack name of <a href="https://www.npmjs.com/package/@cfn-modules/sqs-queue">sqs-queue module</a> where Lambda sends events to after the maximum number of retries was reached</td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>FunctionName</td>
+      <td>An optional but recommended name for the function and log group.</td>
       <td></td>
       <td>no</td>
       <td></td>

--- a/module.yml
+++ b/module.yml
@@ -47,6 +47,10 @@ Parameters:
     Description: 'Optional but recommended for async invocations stack name of sqs-queue module where Lambda sends events to after the maximum number of retries was reached'
     Type: String
     Default: ''
+  FunctionName:
+    Description: 'An optional but recommended name for the function and log group.'
+    Type: String
+    Default: ''
   Description:
     Description: 'Optional description of the function'
     Type: String
@@ -132,6 +136,7 @@ Conditions:
   HasDeadLetterQueueModule: !Not [!Equals [!Ref DeadLetterQueueModule, '']]
   HasReservedConcurrentExecutions: !Not [!Equals [!Ref ReservedConcurrentExecutions, -1]]
   HasVpcModule: !Not [!Equals [!Ref VpcModule, '']]
+  HasFunctionName: !Not [!Equals [!Ref FunctionName, '']]
   HasDependencyModule1: !Not [!Equals [!Ref DependencyModule1, '']]
   HasDependencyModule2: !Not [!Equals [!Ref DependencyModule2, '']]
   HasDependencyModule3: !Not [!Equals [!Ref DependencyModule3, '']]
@@ -198,7 +203,7 @@ Resources:
   LogGroup:
     Type: 'AWS::Logs::LogGroup'
     Properties:
-      LogGroupName: !Join ['', ['/aws/lambda/cfn-modules-lambda-', !Select [2, !Split ['/', !Ref 'AWS::StackId']]]]
+      LogGroupName: !If [HasFunctionName, !Sub '/aws/lambda/${FunctionName}', !Join ['', ['/aws/lambda/cfn-modules-lambda-', !Select [2, !Split ['/', !Ref 'AWS::StackId']]]]]
       RetentionInDays: !Ref LogGroupRetentionInDays
   Function:
     Type: 'AWS::Lambda::Function'
@@ -215,7 +220,7 @@ Resources:
           DEPENDENCY1_ARN: !If [HasDependencyModule1, {'Fn::ImportValue': !Sub '${DependencyModule1}-Arn'}, '']
           DEPENDENCY2_ARN: !If [HasDependencyModule2, {'Fn::ImportValue': !Sub '${DependencyModule2}-Arn'}, '']
           DEPENDENCY3_ARN: !If [HasDependencyModule3, {'Fn::ImportValue': !Sub '${DependencyModule3}-Arn'}, '']
-      FunctionName: !Join ['', ['cfn-modules-lambda-', !Select [2, !Split ['/', !Ref 'AWS::StackId']]]] # we need to "fix" the name to be able to create the LogGroup in advance
+      FunctionName: !If [HasFunctionName, !Ref FunctionName, !Join ['', ['cfn-modules-lambda-', !Select [2, !Split ['/', !Ref 'AWS::StackId']]]]]
       Handler: !Ref Handler
       KmsKeyArn: !If [HasKmsKeyModule, {'Fn::ImportValue': !Sub '${KmsKeyModule}-Arn'}, !Ref 'AWS::NoValue']
       MemorySize: !Ref MemorySize

--- a/test/named.yml
+++ b/test/named.yml
@@ -1,0 +1,12 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'cfn-modules test'
+Resources:
+  Function:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      Parameters:
+        Handler: 'defaults.handler'
+        Runtime: 'nodejs8.10'
+        FunctionName: 'NamedLambda'
+      TemplateURL: './node_modules/@cfn-modules/lambda-function/module.yml'

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -1783,7 +1783,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1801,11 +1802,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1818,15 +1821,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1929,7 +1935,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1939,6 +1946,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1951,17 +1959,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1978,6 +1989,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2050,7 +2062,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2060,6 +2073,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2135,7 +2149,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2165,6 +2180,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2182,6 +2198,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2220,11 +2237,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,17 @@ test.serial('defaults', async t => {
   }
 });
 
+test.serial('named', async t => {
+  const stackName = cfntest.stackName();
+  try {
+    t.log(await cfntest.createStack(`${__dirname}/named.yml`, stackName, {}));
+    // what could we test here?
+  } finally {
+    t.log(await cfntest.deleteStack(stackName));
+    t.pass();
+  }
+});
+
 test.serial('lambda-layer', async t => {
   const bucketStackName = cfntest.stackName();
   const stackName = cfntest.stackName();


### PR DESCRIPTION
Hi! we have found that having control over the names of these functions and log groups we are more easily able to navigate the functions within the console. Hopefully you can see some benefit here too. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
